### PR TITLE
LanguageSelector renders nothing for single-locale sites (#143)

### DIFF
--- a/src/components/layout/LanguageSelector.test.tsx
+++ b/src/components/layout/LanguageSelector.test.tsx
@@ -1,0 +1,42 @@
+// ABOUTME: Tests for the LanguageSelector component
+// ABOUTME: Covers variant auto-detection and single-locale rendering
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LanguageSelector } from './LanguageSelector';
+import { I18nProvider } from '../I18nProvider';
+import type { I18nConfig } from '../../lib/i18n/types';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+function renderWithLocales(locales: string[], currentLocale: string) {
+  const config: I18nConfig = {
+    locales,
+    defaultLocale: locales[0],
+    localeNames: { fr: 'Français', en: 'English', es: 'Español' },
+  };
+  return render(
+    <I18nProvider config={config}>
+      <LanguageSelector currentLocale={currentLocale} />
+    </I18nProvider>
+  );
+}
+
+describe('LanguageSelector', () => {
+  it('renders nothing when only one locale is configured', () => {
+    const { container } = renderWithLocales(['fr'], 'fr');
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a text toggle for two locales', () => {
+    renderWithLocales(['fr', 'en'], 'fr');
+    expect(screen.getByRole('link', { name: 'Switch to English' })).toBeInTheDocument();
+  });
+
+  it('renders a dropdown for three or more locales', () => {
+    renderWithLocales(['fr', 'en', 'es'], 'fr');
+    expect(screen.getByRole('button', { name: 'Select language' })).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/LanguageSelector.tsx
+++ b/src/components/layout/LanguageSelector.tsx
@@ -51,6 +51,11 @@ export function LanguageSelector({
 }: LanguageSelectorProps) {
   const { locales } = useI18n();
 
+  // No language to switch to
+  if (locales.length < 2) {
+    return null;
+  }
+
   // Auto-detect variant based on locale count
   const finalVariant = variant === 'auto'
     ? locales.length === 2 ? 'text' : 'dropdown'


### PR DESCRIPTION
## Summary
- `LanguageSelector` now returns `null` when fewer than 2 locales are configured, instead of rendering a pointless one-item dropdown
- Adds component tests covering single-locale (null), two locales (text toggle), and 3+ locales (dropdown)

## Verification
- TDD: single-locale test failed before the fix (dropdown rendered), passes after
- Full suite: 633 tests pass

Fixes #143