### PR TITLE
Header/Footer honor localePrefix mode on internal links (#142)

### DIFF
--- a/src/components/layout/Footer.test.tsx
+++ b/src/components/layout/Footer.test.tsx
@@ -1,0 +1,71 @@
+// ABOUTME: Tests for the Footer component
+// ABOUTME: Verifies footer links honor the configured localePrefix mode
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Footer } from './Footer';
+import { I18nProvider } from '../I18nProvider';
+import type { I18nConfig, LocalePrefix } from '../../lib/i18n/types';
+import type { FooterConfig } from '../../config/navigation.schema';
+
+const footerConfig: FooterConfig = {
+  copyright: { fr: '© {year} Mon Site', en: '© {year} My Site' },
+  sections: [
+    {
+      heading: { fr: 'Liens', en: 'Links' },
+      links: [
+        { id: 'photos', label: { fr: 'Photos', en: 'Photos' }, href: '/photos' },
+        {
+          id: 'github',
+          label: { fr: 'GitHub', en: 'GitHub' },
+          href: 'https://github.com/zoyth',
+          external: true,
+        },
+      ],
+    },
+  ],
+};
+
+function renderFooter(localePrefix: LocalePrefix, locale: string, locales: string[] = ['fr', 'en']) {
+  const config: I18nConfig = {
+    locales,
+    defaultLocale: 'fr',
+    localePrefix,
+  };
+  return render(
+    <I18nProvider config={config}>
+      <Footer locale={locale} config={footerConfig} />
+    </I18nProvider>
+  );
+}
+
+function linkHref(name: string): string | null {
+  return screen.getByRole('link', { name }).getAttribute('href');
+}
+
+describe('Footer links', () => {
+  it('omits the locale prefix when localePrefix is never', () => {
+    renderFooter('never', 'fr', ['fr']);
+    expect(linkHref('Photos')).toBe('/photos');
+  });
+
+  it('always prefixes when localePrefix is always', () => {
+    renderFooter('always', 'fr');
+    expect(linkHref('Photos')).toBe('/fr/photos');
+  });
+
+  it('omits the prefix for the default locale when localePrefix is as-needed', () => {
+    renderFooter('as-needed', 'fr');
+    expect(linkHref('Photos')).toBe('/photos');
+  });
+
+  it('prefixes non-default locales when localePrefix is as-needed', () => {
+    renderFooter('as-needed', 'en');
+    expect(linkHref('Photos')).toBe('/en/photos');
+  });
+
+  it('leaves external links untouched', () => {
+    renderFooter('always', 'fr');
+    expect(linkHref('GitHub')).toBe('https://github.com/zoyth');
+  });
+});

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,8 +1,12 @@
 // ABOUTME: Site footer from navigation configuration
 // ABOUTME: Multi-column footer layout with sections and links
 
+'use client';
+
 import Image from 'next/image';
 import { type Locale } from '../../lib/i18n/config';
+import { applyLocalePrefix } from '../../lib/i18n/locale-path';
+import { useI18n } from '../I18nProvider';
 import { type FooterConfig } from '../../config/navigation.schema';
 import { getNavigationString, replaceVariables } from '../../lib/navigation';
 
@@ -47,6 +51,7 @@ function renderWithLangBadge(text: string): React.ReactNode {
 }
 
 export function Footer({ locale, config }: FooterProps) {
+  const { localePrefix, defaultLocale } = useI18n();
   const currentYear = new Date().getFullYear();
 
   const copyrightText = replaceVariables(
@@ -77,7 +82,9 @@ export function Footer({ locale, config }: FooterProps) {
                     <li key={link.id}>
                       <a
                         href={
-                          link.external ? getHref(link.href) : `/${locale}${getHref(link.href)}`
+                          link.external
+                            ? getHref(link.href)
+                            : applyLocalePrefix(getHref(link.href), locale, localePrefix, defaultLocale)
                         }
                         {...(link.external && {
                           target: '_blank',

--- a/src/components/layout/Header.test.tsx
+++ b/src/components/layout/Header.test.tsx
@@ -1,0 +1,75 @@
+// ABOUTME: Tests for the Header component
+// ABOUTME: Verifies nav links honor the configured localePrefix mode
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Header } from './Header';
+import { I18nProvider } from '../I18nProvider';
+import type { I18nConfig, LocalePrefix } from '../../lib/i18n/types';
+import type { HeaderConfig } from '../../config/navigation.schema';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+const headerConfig: HeaderConfig = {
+  logo: { text: { fr: 'Mon Site', en: 'My Site' }, href: '/' },
+  mainNav: [
+    { id: 'photos', label: { fr: 'Photos', en: 'Photos' }, href: '/photos' },
+    {
+      id: 'github',
+      label: { fr: 'GitHub', en: 'GitHub' },
+      href: 'https://github.com/zoyth',
+      external: true,
+    },
+  ],
+  utilityNav: [],
+};
+
+function renderHeader(localePrefix: LocalePrefix, locale: string, locales: string[] = ['fr', 'en']) {
+  const config: I18nConfig = {
+    locales,
+    defaultLocale: 'fr',
+    localePrefix,
+  };
+  return render(
+    <I18nProvider config={config}>
+      <Header locale={locale} config={headerConfig} />
+    </I18nProvider>
+  );
+}
+
+function navHref(name: string): string | null {
+  return screen.getAllByRole('link', { name })[0].getAttribute('href');
+}
+
+describe('Header nav links', () => {
+  it('omits the locale prefix when localePrefix is never', () => {
+    renderHeader('never', 'fr', ['fr']);
+    expect(navHref('Photos')).toBe('/photos');
+    expect(navHref('Mon Site')).toBe('/');
+  });
+
+  it('always prefixes when localePrefix is always', () => {
+    renderHeader('always', 'fr');
+    expect(navHref('Photos')).toBe('/fr/photos');
+    expect(navHref('Mon Site')).toBe('/fr');
+  });
+
+  it('omits the prefix for the default locale when localePrefix is as-needed', () => {
+    renderHeader('as-needed', 'fr');
+    expect(navHref('Photos')).toBe('/photos');
+    expect(navHref('Mon Site')).toBe('/');
+  });
+
+  it('prefixes non-default locales when localePrefix is as-needed', () => {
+    renderHeader('as-needed', 'en');
+    expect(navHref('Photos')).toBe('/en/photos');
+    expect(navHref('My Site')).toBe('/en');
+  });
+
+  it('leaves external links untouched', () => {
+    renderHeader('always', 'fr');
+    expect(navHref('GitHub')).toBe('https://github.com/zoyth');
+  });
+});

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,6 +7,8 @@ import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { type Locale } from '../../lib/i18n/config';
+import { applyLocalePrefix } from '../../lib/i18n/locale-path';
+import { useI18n } from '../I18nProvider';
 import { LanguageSelector } from './LanguageSelector';
 import { type HeaderConfig, type NavItem, type NavLink } from '../../config/navigation.schema';
 import { getNavigationString } from '../../lib/navigation';
@@ -17,6 +19,7 @@ export interface HeaderProps {
 }
 
 export function Header({ locale, config }: HeaderProps) {
+  const { localePrefix, defaultLocale } = useI18n();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
 
@@ -33,9 +36,7 @@ export function Header({ locale, config }: HeaderProps) {
     if (external || href.startsWith('http')) {
       return href;
     }
-    // Remove leading slash if present to avoid double slashes
-    const cleanHref = href.startsWith('/') ? href.slice(1) : href;
-    return `/${locale}/${cleanHref}`;
+    return applyLocalePrefix(href, locale, localePrefix, defaultLocale);
   };
 
   return (

--- a/src/lib/i18n/locale-path.test.ts
+++ b/src/lib/i18n/locale-path.test.ts
@@ -68,6 +68,23 @@ describe('localePath', () => {
     expect(localePath('/', 'en')).toBe('/en');
   });
 
+  it('never prefixes in never mode', () => {
+    __resetI18nConfig__();
+    setI18nConfig({ ...testConfig, localePrefix: 'never' });
+
+    expect(localePath('/bilan', 'fr')).toBe('/bilan');
+    expect(localePath('/bilan', 'en')).toBe('/health-check');
+    expect(localePath('/contact', 'fr')).toBe('/contact');
+  });
+
+  it('handles never prefix mode root path', () => {
+    __resetI18nConfig__();
+    setI18nConfig({ ...testConfig, localePrefix: 'never' });
+
+    expect(localePath('/', 'fr')).toBe('/');
+    expect(localePath('/', 'en')).toBe('/');
+  });
+
   it('accepts custom slug translations that override config', () => {
     const custom = { fr: { '/bilan': '/checkup' } };
     expect(localePath('/bilan', 'en', custom)).toBe('/en/checkup');

--- a/src/lib/i18n/locale-path.ts
+++ b/src/lib/i18n/locale-path.ts
@@ -1,9 +1,41 @@
 // ABOUTME: Convenience function for building locale-prefixed internal links
 // ABOUTME: Translates canonical paths and prepends the correct locale prefix
 
-import type { SlugTranslations } from './types';
+import type { LocalePrefix, SlugTranslations } from './types';
 import { getI18nConfig, getLocalePrefix, getDefaultLocale } from './config';
 import { translateSlug } from './slug-translations';
+
+/**
+ * Prepend the locale prefix to a path according to the prefix mode
+ *
+ * @param path - Internal path (e.g. '/photos')
+ * @param locale - Target locale
+ * @param prefixMode - Configured locale prefix mode
+ * @param defaultLocale - The site's default locale
+ * @returns Path with the locale prefix applied when the mode requires it
+ */
+export function applyLocalePrefix(
+  path: string,
+  locale: string,
+  prefixMode: LocalePrefix,
+  defaultLocale: string
+): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  const skipPrefix =
+    prefixMode === 'never' ||
+    (prefixMode === 'as-needed' && locale === defaultLocale);
+  if (skipPrefix) {
+    return normalizedPath;
+  }
+
+  // Handle root path
+  if (normalizedPath === '/') {
+    return `/${locale}`;
+  }
+
+  return `/${locale}${normalizedPath}`;
+}
 
 /**
  * Build a locale-prefixed internal link from a canonical (default-locale) path
@@ -41,15 +73,5 @@ export function localePath(
   }
 
   // Apply locale prefix
-  const skipPrefix = prefixMode === 'as-needed' && locale === defaultLocale;
-  if (skipPrefix) {
-    return translated;
-  }
-
-  // Handle root path
-  if (translated === '/') {
-    return `/${locale}`;
-  }
-
-  return `/${locale}${translated}`;
+  return applyLocalePrefix(translated, locale, prefixMode, defaultLocale);
 }


### PR DESCRIPTION
## Summary
- `Header.buildHref` and Footer's link building no longer hardcode `/{locale}/` — they apply the configured `localePrefix` mode (`never` → no prefix, `as-needed` → prefix only non-default locales, `always` → unchanged)
- `localePath()` had the same bug: it ignored `'never'` mode entirely. Extracted `applyLocalePrefix()` implementing all three modes, shared by `localePath`, Header, and Footer
- Header/Footer read `localePrefix`/`defaultLocale` from `I18nProvider` context (module-level config isn't reliably initialized client-side). Header already required the provider via `LanguageSelector`; Footer now does too and gains `'use client'` — a no-op for consumers since the components bundle already ships with a `'use client'` banner

## Verification
- TDD: new `localePath` 'never' tests + 10 Header/Footer component tests across all three prefix modes failed before the fix, pass after
- Full suite: 642 tests pass; `npm run build` succeeds

Fixes #142