### PR TITLE
Align language toggle with Header nav items (#138)

### DIFF
--- a/src/components/layout/LanguageSelector.test.tsx
+++ b/src/components/layout/LanguageSelector.test.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for the LanguageSelector component
-// ABOUTME: Covers variant auto-detection and single-locale rendering
+// ABOUTME: Covers variant auto-detection, single-locale rendering, and nav alignment
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -38,5 +38,16 @@ describe('LanguageSelector', () => {
   it('renders a dropdown for three or more locales', () => {
     renderWithLocales(['fr', 'en', 'es'], 'fr');
     expect(screen.getByRole('button', { name: 'Select language' })).toBeInTheDocument();
+  });
+});
+
+describe('LanguageSelector text toggle', () => {
+  it('matches the nav item baseline offset (pb-1 + transparent bottom border)', () => {
+    renderWithLocales(['fr', 'en'], 'fr');
+
+    const toggle = screen.getByRole('link', { name: 'Switch to English' });
+    expect(toggle.className).toContain('pb-1');
+    expect(toggle.className).toContain('border-b-2');
+    expect(toggle.className).toContain('border-transparent');
   });
 });

--- a/src/components/layout/LanguageSelector.tsx
+++ b/src/components/layout/LanguageSelector.tsx
@@ -121,6 +121,7 @@ function TextToggle({
       className={cn(
         'text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors',
         'inline-flex items-center h-10', // Match hamburger button height (p-2 + 24px icon = 40px)
+        'pb-1 border-b-2 border-transparent', // Match nav item baseline offset
         className
       )}
       aria-label={`Switch to ${displayText}`}


### PR DESCRIPTION
## Summary
- Adds `pb-1 border-b-2 border-transparent` to the LanguageSelector TextToggle anchor so its text baseline matches nav items (which use `pb-1 border-b-2` for the active underline)

## Verification
- TDD: class assertion test failed before, passes after
- Full suite passes

Note: touches the same files as #145 — whichever merges second will need a trivial conflict resolution (both add `LanguageSelector.test.tsx`). Happy to rebase after the first merge.

Fixes #138