### PR TITLE
Add dependency-light ./tailwind subpath export (#141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Your project's `tailwind.config.ts` must include the framework components in the
 
 ```typescript
 import type { Config } from 'tailwindcss';
-import { getTailwindColors } from '@zoyth/simple-site-framework';
+import { getTailwindColors } from '@zoyth/simple-site-framework/tailwind';
 import { myTheme } from './src/config/theme';
 
 const config: Config = {

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,7 +28,7 @@ Without this line, Tailwind won't scan the framework components and won't genera
 With `ThemeConfigV2`, use `getTailwindColors()` and `getTailwindContentConfig()`:
 
 ```typescript
-import { getTailwindColors, getTailwindContentConfig } from '@zoyth/simple-site-framework';
+import { getTailwindColors, getTailwindContentConfig } from '@zoyth/simple-site-framework/tailwind';
 import { theme } from './src/config/theme';
 
 const config: Config = {
@@ -164,7 +164,7 @@ If your logo appears too large, add or adjust the `displayHeight` property. If n
 **Fix**: Use `getTailwindContentConfig()` in your Tailwind config:
 
 ```typescript
-import { getTailwindContentConfig } from '@zoyth/simple-site-framework';
+import { getTailwindContentConfig } from '@zoyth/simple-site-framework/tailwind';
 
 export default {
   content: {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/config/index.mjs",
       "require": "./dist/config/index.js"
     },
+    "./tailwind": {
+      "types": "./dist/tailwind.d.ts",
+      "import": "./dist/tailwind.mjs",
+      "require": "./dist/tailwind.js"
+    },
     "./lib/i18n": {
       "types": "./dist/index.d.ts",
       "import": "./dist/lib/i18n/index.mjs",

--- a/src/lib/theme/tailwind.ts
+++ b/src/lib/theme/tailwind.ts
@@ -31,7 +31,7 @@ function colorVar(name: string): TailwindColorValue {
  * @example
  * ```ts
  * // tailwind.config.ts
- * import { getTailwindColors } from '@zoyth/simple-site-framework';
+ * import { getTailwindColors } from '@zoyth/simple-site-framework/tailwind';
  * import { theme } from './src/config/theme';
  *
  * export default {
@@ -116,7 +116,7 @@ export function stripTailwindFalsePositives(content: string): string {
  * @example
  * ```ts
  * // tailwind.config.ts
- * import { getTailwindContentConfig } from '@zoyth/simple-site-framework';
+ * import { getTailwindContentConfig } from '@zoyth/simple-site-framework/tailwind';
  *
  * export default {
  *   content: {

--- a/src/tailwind-entry.test.ts
+++ b/src/tailwind-entry.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Verifies the ./tailwind subpath ships Tailwind config helpers without the MDX chain
+// ABOUTME: Guards against tailwind.config evaluation (jiti/Turbopack) pulling in ESM-only deps
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+const root = path.resolve(__dirname, '..');
+const pkg = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+
+describe('./tailwind subpath export', () => {
+  it('is declared in the exports map with types, import, and require entries', () => {
+    const entry = pkg.exports['./tailwind'];
+    expect(entry, './tailwind missing from package.json exports').toBeDefined();
+    expect(entry.types).toBeDefined();
+    expect(entry.import).toBeDefined();
+    expect(entry.require).toBeDefined();
+  });
+
+  it('loads under CJS with the Tailwind helpers, without the MDX dependency chain', () => {
+    const requirePath = pkg.exports['./tailwind']?.require;
+    expect(requirePath, './tailwind has no require entry').toBeDefined();
+    expect(existsSync(path.join(root, requirePath)), `${requirePath} not built`).toBe(true);
+
+    // Load in a child process the way jiti/node would evaluate tailwind.config,
+    // then report which modules ended up in the require cache.
+    const script = `
+      const helpers = require(${JSON.stringify(path.join(root, requirePath))});
+      const loaded = Object.keys(require.cache);
+      console.log(JSON.stringify({
+        exports: Object.keys(helpers).sort(),
+        mdxChain: loaded.filter((p) =>
+          /node_modules\\/(remark-gfm|rehype-slug|estree-walker|mdast|micromark)/.test(p)
+        ),
+      }));
+    `;
+    const result = JSON.parse(execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' }));
+
+    expect(result.exports).toContain('getTailwindColors');
+    expect(result.exports).toContain('getTailwindContentConfig');
+    expect(result.exports).toContain('stripTailwindFalsePositives');
+    expect(result.mdxChain).toEqual([]);
+  });
+});

--- a/src/tailwind.ts
+++ b/src/tailwind.ts
@@ -1,0 +1,9 @@
+// ABOUTME: Tailwind config helpers entry point
+// ABOUTME: Dependency-light so tailwind.config evaluation (jiti/Turbopack) never loads the MDX chain
+
+export {
+  getTailwindColors,
+  getTailwindContentConfig,
+  stripTailwindFalsePositives,
+} from './lib/theme/tailwind';
+export type { ThemeConfig, ThemeConfigV1, ThemeConfigV2 } from './config/theme.schema';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       'config/index': 'src/config/index.ts',
+      tailwind: 'src/tailwind.ts',
     },
     format: ['cjs', 'esm'],
     dts: true,


### PR DESCRIPTION
## Summary
- New `@zoyth/simple-site-framework/tailwind` subpath exporting `getTailwindColors`, `getTailwindContentConfig`, and `stripTailwindFalsePositives` (plus theme config types) without the root bundle's remark/rehype chain
- README/TROUBLESHOOTING/JSDoc examples now import the Tailwind helpers from the subpath

## Verification
- TDD: new test asserts the exports map entry exists and that requiring the built `dist/tailwind.js` in a child process exposes the helpers with zero remark-gfm/rehype-slug/estree-walker/micromark modules in the require cache — failed before, passes after
- E2E: packed the tarball, installed in a clean project, `require('@zoyth/simple-site-framework/tailwind')` resolves and returns the three helpers
- Full suite: 632 tests pass; build succeeds

Fixes #141