### PR TITLE
Escape Prism regex Tailwind false positives in dist output (#137)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "bin"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/escape-tailwind-false-positives.js",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest",

--- a/scripts/escape-tailwind-false-positives.js
+++ b/scripts/escape-tailwind-false-positives.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+// ABOUTME: Rewrites [-:=] to [-\x3a=] in dist output so Tailwind v4's scanner
+// ABOUTME: never sees a token it would compile into invalid CSS (crashes Turbopack)
+
+const fs = require('fs');
+const path = require('path');
+
+const TOKEN = '[-:=]';
+// \x3a is ':' in both regex and string literals, so runtime behavior is identical
+const REPLACEMENT = '[-\\x3a=]';
+
+const distDir = path.join(__dirname, '..', 'dist');
+
+function walk(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    if (fs.statSync(fullPath).isDirectory()) {
+      files.push(...walk(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function escapeSourceMap(file) {
+  // Source maps are JSON: replace inside the parsed strings so the
+  // backslash gets re-escaped correctly on serialization
+  const map = JSON.parse(fs.readFileSync(file, 'utf8'));
+  let changed = false;
+  if (Array.isArray(map.sourcesContent)) {
+    map.sourcesContent = map.sourcesContent.map((source) => {
+      if (typeof source === 'string' && source.includes(TOKEN)) {
+        changed = true;
+        return source.split(TOKEN).join(REPLACEMENT);
+      }
+      return source;
+    });
+  }
+  if (changed) {
+    fs.writeFileSync(file, JSON.stringify(map));
+  }
+  return changed;
+}
+
+function escapeText(file) {
+  const content = fs.readFileSync(file, 'utf8');
+  if (!content.includes(TOKEN)) {
+    return false;
+  }
+  fs.writeFileSync(file, content.split(TOKEN).join(REPLACEMENT));
+  return true;
+}
+
+let patched = 0;
+for (const file of walk(distDir)) {
+  const changed = file.endsWith('.map') ? escapeSourceMap(file) : escapeText(file);
+  if (changed) {
+    patched++;
+    console.log(`escaped ${TOKEN} in ${path.relative(distDir, file)}`);
+  }
+}
+console.log(`escape-tailwind-false-positives: ${patched} file(s) patched`);

--- a/src/dist-prism-false-positives.test.ts
+++ b/src/dist-prism-false-positives.test.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Verifies shipped dist files contain no [-:=] tokens that Tailwind v4 scans as classes
+// ABOUTME: Guards against Prism grammar regexes crashing Turbopack's CSS parser in consumer builds
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import path from 'path';
+
+const distDir = path.resolve(__dirname, '..', 'dist');
+
+function walk(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      files.push(...walk(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+describe('dist Tailwind false positives', () => {
+  it('ships no [-:=] token anywhere in dist', () => {
+    const offenders = walk(distDir).filter((file) =>
+      readFileSync(file, 'utf8').includes('[-:=]')
+    );
+    expect(
+      offenders.map((f) => path.relative(distDir, f)),
+      'Tailwind v4 parses [-:=] as an arbitrary property class and emits invalid CSS'
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a post-build step (`scripts/escape-tailwind-false-positives.js`, wired into `npm run build`) that rewrites `[-:=]` → `[-\x3a=]` across all dist files — bundles, type definitions, and source maps (JSON-aware so map escaping stays valid)
- `\x3a` is `:` in both regex and string literals, so runtime behavior is byte-identical; Tailwind v4's scanner just never sees a token it would compile into invalid CSS

## Verification
- TDD: new test walks `dist/` and asserts no file contains `[-:=]` — failed with 8 offenders before, passes after
- Patched components bundle still loads (103 exports), patched maps parse as valid JSON, regex equivalence checked
- Full suite passes

Fixes #137