### PR TITLE
Fix typecheck errors that kept CI red

### DIFF
--- a/src/components/I18nProvider.test.tsx
+++ b/src/components/I18nProvider.test.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for I18nProvider context and useI18n hook
 // ABOUTME: Verifies config propagation, helper derivation, and error on missing provider
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { renderHook } from '@testing-library/react';
 import { I18nProvider, useI18n } from './I18nProvider';

--- a/src/components/NewsletterSignup.test.tsx
+++ b/src/components/NewsletterSignup.test.tsx
@@ -1,9 +1,10 @@
 // ABOUTME: Tests for NewsletterSignup component
 // ABOUTME: Verifies variants, validation, submission states, honeypot, and accessibility
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { NewsletterSignup } from './NewsletterSignup';
+import type { NewsletterResponse } from './NewsletterSignup';
 
 const mockOnSubmit = vi.fn().mockResolvedValue({ success: true });
 
@@ -183,9 +184,9 @@ describe('NewsletterSignup', () => {
     });
 
     it('disables button while submitting', async () => {
-      let resolveSubmit: (value: any) => void;
+      let resolveSubmit: (value: NewsletterResponse) => void;
       const slowSubmit = vi.fn(
-        () => new Promise((resolve) => { resolveSubmit = resolve; })
+        () => new Promise<NewsletterResponse>((resolve) => { resolveSubmit = resolve; })
       );
       render(<NewsletterSignup onSubmit={slowSubmit} />);
       fireEvent.change(screen.getByRole('textbox', { name: /email/i }), {

--- a/src/components/a11y/CheckboxGroupARIA.test.tsx
+++ b/src/components/a11y/CheckboxGroupARIA.test.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Tests for ARIA-enhanced CheckboxGroup component
 // ABOUTME: Validates group semantics, keyboard navigation, and screen reader support
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CheckboxGroupARIA } from './CheckboxGroupARIA';

--- a/src/components/forms/ContactForm.test.tsx
+++ b/src/components/forms/ContactForm.test.tsx
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ContactForm } from './ContactForm';
 import type { ContactFormData, ContactFormResponse } from './ContactForm';
 
 describe('ContactForm', () => {
-  const mockSubmit = vi.fn<[ContactFormData], Promise<ContactFormResponse>>();
+  const mockSubmit = vi.fn<(data: ContactFormData) => Promise<ContactFormResponse>>();
 
   beforeEach(() => {
     mockSubmit.mockClear();

--- a/src/components/forms/LeadForm.test.tsx
+++ b/src/components/forms/LeadForm.test.tsx
@@ -8,7 +8,7 @@ import { LeadForm } from './LeadForm';
 import type { LeadFormData } from './LeadForm';
 
 describe('LeadForm', () => {
-  const mockSubmit = vi.fn<[LeadFormData], Promise<void>>();
+  const mockSubmit = vi.fn<(data: LeadFormData) => Promise<void>>();
 
   beforeEach(() => {
     mockSubmit.mockClear();

--- a/src/components/sections/CaseStudySection.test.tsx
+++ b/src/components/sections/CaseStudySection.test.tsx
@@ -187,7 +187,7 @@ describe('CaseStudySection', () => {
 
   it('uses custom CTA renderer when provided', () => {
     const customCTA = (caseStudy: CaseStudy) => (
-      <button className="custom-cta">Custom CTA for {caseStudy.company}</button>
+      <button className="custom-cta">Custom CTA for {caseStudy.company as string}</button>
     );
 
     render(<CaseStudySection caseStudies={[mockCaseStudy]} renderCTA={customCTA} />);

--- a/src/lib/theme/tailwind.ts
+++ b/src/lib/theme/tailwind.ts
@@ -3,7 +3,7 @@
 
 import { type ThemeConfigV2 } from '../../config/theme.schema';
 
-type TailwindColorValue = (opts: { opacityValue?: string }) => string;
+export type TailwindColorValue = (opts: { opacityValue?: string }) => string;
 
 /**
  * Create a Tailwind v3 color value function that supports opacity modifiers.
@@ -41,7 +41,7 @@ function colorVar(name: string): TailwindColorValue {
  */
 export function getTailwindColors(
   config: ThemeConfigV2
-): Record<string, string | Record<number, string>> {
+): Record<string, TailwindColorValue | Record<number, TailwindColorValue>> {
   const colors: Record<string, any> = {};
 
   // Brand palette


### PR DESCRIPTION
## Summary
Every CI run on `main` has been failing at the `npm run typecheck` step. All 58 errors were in test files (plus one lying type annotation):
- Several test files used `vi`/`beforeEach` without importing them — added explicit imports
- `vi.fn<[Args], Return>()` is vitest ≤3 syntax; vitest 4 takes a single function-signature generic — updated `ContactForm`/`LeadForm` tests
- `getTailwindColors` declared `Record<string, string | Record<number, string>>` but actually returns Tailwind color-value functions — fixed the annotation (and exported `TailwindColorValue`), which removes the invalid casts in its test
- Typed the deferred-resolve promise in the NewsletterSignup submit test

## Verification
- `npm run typecheck`: 0 errors (was 58)
- Full suite: 630 tests pass; build succeeds

This unblocks green CI checks for #144–#149.